### PR TITLE
Use --virtual-time-budget instead of --timeout for faster render times

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ func (app *application) execChrome(ctxMain context.Context, action, url string, 
 		"--headless",
 		"--disable-gpu",
 		"--disable-software-rasterizer",
-		"--timeout=55000", // 55 secs, context timeout is 1 minute
+		"--virtual-time-budget=55000", // 55 secs, context timeout is 1 minute
 		"--disable-dev-shm-usage",
 		"--hide-scrollbars",
 		"--disable-crash-reporter",


### PR DESCRIPTION
If you specify `--virtual-time-budget` in Chrome CLI flags, it doesn't need to wait for the specified amount of real-world time, but fast-forwards all the animations etc. and returns immediately. This results in much quicker render times for `html2pdf`.

See https://stackoverflow.com/questions/53548438/what-does-the-argument-virtual-time-budget-of-chrome-cli-really-mean