### PR TITLE
Add Debian-based Docker image

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -16,6 +16,14 @@ jobs:
       contents: read
       packages: write
 
+    strategy:
+      matrix:
+        include:
+          - dockerfile: Dockerfile
+            suffix: ""
+          - dockerfile: Dockerfile.debian
+            suffix: "-debian"
+
     steps:
       - name: checkout sources
         uses: actions/checkout@v6
@@ -43,7 +51,8 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           push: true
+          file: ${{ matrix.dockerfile }}
           # platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/386,linux/ppc64le
           tags: |
-            firefart/gochro:latest
-            ghcr.io/firefart/gochro:latest
+            firefart/gochro:latest${{ matrix.suffix }}
+            ghcr.io/firefart/gochro:latest${{ matrix.suffix }}

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,28 @@
+FROM golang:latest AS build-env
+WORKDIR /src
+ENV CGO_ENABLED=0
+COPY go.* /src/
+RUN go mod download
+COPY main.go .
+RUN go build -a -o gochro -ldflags="-s -w" -trimpath
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends chromium \
+    && ln -s /usr/bin/chromium /usr/bin/chromium-browser \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /app \
+    && adduser --disabled-password --gecos "" chrome \
+    && chown -R chrome:chrome /app
+
+USER chrome
+WORKDIR /app
+
+ENV CHROME_BIN=/usr/bin/chromium \
+    CHROME_PATH=/usr/lib/chromium/
+
+COPY --from=build-env /src/gochro .
+
+ENTRYPOINT [ "./gochro" ]


### PR DESCRIPTION
Adds a Debian (bookworm-slim) variant of the Docker image to work around Alpine's Chromium package crashing with SIGILL on certain environments.

Relates to #69.

### Changes
- `Dockerfile.debian` — Debian bookworm-slim based image with symlink for `/usr/bin/chromium-browser` compatibility
- CI matrix builds both Alpine (`:latest`) and Debian (`:latest-debian`) tags

### Tested
Built and verified on Xeon Gold 6226R (VMware) where Alpine image crashes — Debian image returns 200 with valid PDF on `POST /html2pdf`.